### PR TITLE
Put replication

### DIFF
--- a/apps/dynamo/lib/dynamo/chash.ex
+++ b/apps/dynamo/lib/dynamo/chash.ex
@@ -111,8 +111,25 @@ defmodule CHash do
     length(chash.node_entries)
   end
 
+
   @doc """
-  Return n_val nodes following index.
+  Return previous n node entries.
+  This is used for preference list
+  """
+  @spec predecessors(index(), non_neg_integer(), %CHash{}) :: [node_entry()]
+  def predecessors(index, n_val, chash) do
+    num = min(n_val, chash.num_partitions)
+    <<index_as_int::160>> = index
+    inc = ring_increment(chash.num_partitions)
+    next_partition_index = div(index_as_int, inc) + 1
+    {first_n, following} = Enum.split(chash.node_entries, next_partition_index)
+    following ++ first_n
+    |> Enum.reverse
+    |> Enum.take(num)
+  end
+
+  @doc """
+  Return following n node entries.
   This is used for preference list
   """
   @spec successors(index(), non_neg_integer(), %CHash{}) :: [node_entry()]
@@ -122,8 +139,7 @@ defmodule CHash do
     inc = ring_increment(chash.num_partitions)
     next_partition_index = div(index_as_int, inc) + 1
     {first_n, following} = Enum.split(chash.node_entries, next_partition_index)
-    {result, _} = Enum.split(following ++ first_n, num)
-    result
+    Enum.take(following ++ first_n, num)
   end
 
   @doc """

--- a/apps/dynamo/lib/dynamo/kv.ex
+++ b/apps/dynamo/lib/dynamo/kv.ex
@@ -8,16 +8,27 @@ defmodule KV do
     Ring.print_status(ring)
   end
 
+  @spec put(term(), term()) :: term()
   def put(key, value) do
     sync_command(key, {:put, key, value})
   end
 
+  @spec get(term()) :: term()
   def get(key) do
     sync_command(key, {:get, key})
   end
 
+  @spec delete(term()) :: term()
   def delete(key) do
     sync_command(key, {:delete, key})
+  end
+
+  @doc """
+  Return key/value store of certain partition.
+  """
+  @spec get_my_data(non_neg_integer()) :: term()
+  def get_my_data(partition) do
+    Vnode.Master.sync_command({partition, Node.self()}, :get_my_data)
   end
 
   def sync_command(key, command) do

--- a/apps/dynamo/lib/dynamo/ring_manager.ex
+++ b/apps/dynamo/lib/dynamo/ring_manager.ex
@@ -7,6 +7,7 @@ defmodule Ring.Manager do
 
   @type chash_node() :: term()
   @type index() :: <<_::160>>
+  @type index_as_int() :: non_neg_integer()
   @type ring() :: Ring
 
   def start_link(opts) do
@@ -32,9 +33,24 @@ defmodule Ring.Manager do
   @doc """
   Return preference list of size n_val
   """
+  def get_preference_list(index, n_val) when is_integer(index) do
+    get_preference_list(<<index::160>>, n_val)
+  end
+
   @spec get_preference_list(index(), integer()) :: [chash_node()]
   def get_preference_list(index, n_val) do
     GenServer.call(__MODULE__, {:get_preference_list, index, n_val})
+  end
+
+  @doc """
+  Return indices that a vnode has to stores. (n-1) previous indicies
+  """
+  def get_replicated_indices(index) when is_integer(index) do
+    get_replicated_indices(<<index::160>>)
+  end
+
+  def get_replicated_indices(index) do
+    GenServer.call(__MODULE__, {:get_replicated_indices, index})
   end
 
   @spec ring_transform(function(), [term()]) :: none()
@@ -56,6 +72,15 @@ defmodule Ring.Manager do
   def handle_call({:get_preference_list, index, n_val}, _from, ring) do
     successors = CHash.successors(index, n_val, ring.chring)
     {:reply, successors, ring}
+  end
+
+  @impl true
+  def handle_call({:get_replicated_indices, index}, _from, ring) do
+    replication_factor = Application.get_env(:dynamo, :replication)
+    predecessors = CHash.predecessors(index, replication_factor, ring.chring)
+    pred_indices = for {index, _node} <- predecessors, do: index
+
+    {:reply, pred_indices, ring}
   end
 
   @impl true

--- a/apps/dynamo/lib/dynamo/vnode.ex
+++ b/apps/dynamo/lib/dynamo/vnode.ex
@@ -4,24 +4,113 @@ defmodule Vnode do
   """
 
   use GenServer
+  require Logger
+
+  @type index_as_int() :: integer()
 
   @doc """
   Start Vnode for partition starting at index.
   """
-  @spec start_vnode(integer()) :: pid()
+  @spec start_vnode(index_as_int()) :: pid()
   def start_vnode(index) do
     Vnode.Manager.get_vnode_pid(index)
   end
 
+  @spec start_link(index_as_int()) :: {:ok, pid()}
   def start_link(index) do
     GenServer.start_link(__MODULE__, index)
   end
 
+  def replicate(key, value) do
+    GenServer.call(__MODULE__, {:repl, key, value})
+  end
+
+  # Replicate operations to following vnodes
+  # This can be reused for put/get/delete operation
+  defp replicate_task(key, value, my_index, num_replication, num_write) do
+    pref_list = Ring.Manager.get_preference_list(my_index, num_replication - 1)
+    pref_indices = MapSet.new(for {index, _node} <- pref_list, do: index)
+    repair_indices = MapSet.new()
+    current_write = 1
+
+    # spawn a asynchronous task for receiving the ack from replicating vnodes
+    task =
+      Dynamo.TaskSupervisor
+      |> Task.Supervisor.async(
+        fn ->
+          wait_write_response(key, value, pref_indices, repair_indices, current_write, num_write)
+        end)
+
+    Logger.info("Receiver Task: #{inspect(task)}")
+
+    # send asynchronous replication task to other vnodes
+    for {index, node} <- pref_list do
+      {:ok, replicate_task_pid} = {Dynamo.TaskSupervisor, node}
+      |> Task.Supervisor.start_child(Vnode.Master, :async_task, [index, {:repl, task.pid, my_index, key, value}])
+      Logger.info("Replicate Task: #{inspect(replicate_task_pid)}")
+    end
+
+    {left_list, repair_indices} = Task.await(task)
+    # TODO : Task for left_list and read repair
+    # after W values have returned :ok from put replication operation
+    # wait for other return for some time and do read repairs.
+  end
+
+  # this is for spawning async task for getting acks from other vnodes
+  defp wait_write_response(key, value, pref_indices, repair_indices, current_write, num_write) do
+    if current_write < num_write do
+      receive do
+        # We need to add vclock or nonce for checking
+        {:ok, ^key, ^value, index} ->
+          # correct return value
+          pref_indices = MapSet.delete(pref_indices, index)
+          wait_write_response(key, value, pref_indices, repair_indices, current_write + 1, num_write)
+        {:ok, ^key, value, index} ->
+          # correct key but wrong return value
+          # needs read repair
+          pref_indices = MapSet.delete(pref_indices, index)
+          repair_indices = MapSet.put(repair_indices, index)
+          wait_write_response(key, value, pref_indices, repair_indices, current_write, num_write)
+        other ->
+          Logger.info("#{inspect(other)}")
+          wait_write_response(key, value, pref_indices, repair_indices, current_write, num_write)
+          # error?
+      end
+    else
+      {pref_indices, repair_indices}
+    end
+  end
+
   # Vnode keeps state partition, the index of partition it's in charge
-  # and data, a key/value store
+  # and data, a key/value stores of indicies.
+  # data is a map of %{index => %{key => value}}
   @impl true
   def init(partition) do
-    {:ok, %{:partition => partition, :data => %{}}}
+    # get indices of previous (n-1) vnodes for replication
+    replicated_indices = Ring.Manager.get_replicated_indices(partition)
+    data =
+      Ring.Manager.get_replicated_indices(partition)
+      |> Map.new(
+        fn index -> {index, %{}}
+      end)
+    {:ok, %{:partition => partition, :data => data}}
+  end
+
+  @doc """
+  Callback for put replication to vnodes.
+  """
+  @impl true
+  def handle_cast({:repl, sender, index, key, value}, state) do
+    Logger.info("replicating #{key}: #{value} to #{state.partition}")
+
+    {_, new_data} =
+      state.data
+      |> Map.get_and_update(index, fn index_store ->
+        {nil, Map.put(index_store, key, value)}
+      end)
+
+    send(sender, {:ok, key, value, state.partition})
+    {:noreply, %{state | data: new_data}}
   end
 
   @impl true
@@ -31,21 +120,40 @@ defmodule Vnode do
 
   @impl true
   def handle_call({:put, key, value}, _from, state) do
-    IO.puts "put #{key}: #{value}"
-    new_data = Map.put(state.data, key, value)
+    Logger.info("put #{key}: #{value}")
+
+    # store key/value to my parition's key/value store
+    {_, new_data} =
+      state.data
+      |> Map.get_and_update(state.partition, fn index_store ->
+        {nil, Map.put(index_store, key, value)}
+      end)
+
+    replicate_task(key, value, state.partition, 3, 2)
     {:reply, :ok, %{state | data: new_data}}
   end
 
   @impl true
   def handle_call({:get, key}, _from, state) do
-    IO.puts "get #{key}"
-    {:reply, Map.get(state.data, key, :key_not_found), state}
+    Logger.info("get #{key}")
+    # TODO : Check R get values from other vnodes
+    value =
+      state.data
+      |> Map.get(state.partition)
+      |> Map.get(key, :key_not_found)
+    {:reply, value, state}
   end
 
   @impl true
   def handle_call({:delete, key}, _from, state) do
-    IO.puts "delete #{key}"
+    # TODO : quorum checking
+    Logger.info("delete #{key}")
     new_data = Map.delete(state.data, key)
     {:reply, Map.get(state.data, key, :key_not_found), %{state | data: new_data}}
+  end
+
+  @impl true
+  def handle_call(:get_my_data, _from, state) do
+    {:reply, state.data, state}
   end
 end

--- a/apps/dynamo/lib/dynamo/vnode_master.ex
+++ b/apps/dynamo/lib/dynamo/vnode_master.ex
@@ -4,11 +4,23 @@ defmodule Vnode.Master do
   """
 
   use GenServer
+  require Logger
 
   @type index_as_int() :: integer()
 
   def start_link(opts) do
     GenServer.start_link(__MODULE__, :ok, opts)
+  end
+
+  def async_task(index, msg) do
+    Logger.info("Received async command #{inspect(msg)}")
+    pid = Vnode.Manager.get_vnode_pid(index)
+    result = GenServer.cast(pid, msg)
+  end
+
+  @spec command(index_as_int(), term()) :: term()
+  def command({index, node}, msg) do
+    GenServer.cast({__MODULE__, node}, {:command, Node.self(), index, msg})
   end
 
   @doc """
@@ -25,10 +37,18 @@ defmodule Vnode.Master do
     {:ok, []}
   end
 
+  @impl true
+  def handle_cast({:command, sender, index, msg}, state) do
+    Logger.info("Received command #{inspect(msg)} from #{sender}")
+    pid = Vnode.Manager.get_vnode_pid(index)
+    result = GenServer.cast(pid, msg)
+    {:noreply, state}
+  end
+
   # Find pid of vnode responsible for hat index and send command.
   @impl true
   def handle_call({:sync_command, sender, index, msg}, _from, state) do
-    IO.puts "Received command #{inspect(msg)} from #{sender}"
+    Logger.info("Received sync command #{inspect(msg)} from #{sender}")
     pid = Vnode.Manager.get_vnode_pid(index)
     result = GenServer.call(pid, msg)
     {:reply, result, state}

--- a/apps/dynamo/test/chash_test.exs
+++ b/apps/dynamo/test/chash_test.exs
@@ -32,13 +32,16 @@ defmodule CHashTest do
     node = "old@host"
     new_node = "new@host"
 
-    chash = CHash.new_ring(8, node)
+    partition_size = 8
+    chash = CHash.new_ring(partition_size, node)
     {:ok, {index, _}} = Enum.fetch(chash.node_entries, 3)
     updated_ring = CHash.update_owner(index, new_node, chash)
     bin_index = <<(index - 10)::160>>
-    successors = CHash.successors(bin_index, 8, updated_ring)
+    successors = CHash.successors(bin_index, partition_size, updated_ring)
 
-    assert length(successors) == 8
+    assert length(successors) == partition_size
     assert {:ok, {_, ^new_node}} = Enum.fetch(successors, 0)
+    assert CHash.predecessors(<<0::160>>, partition_size, chash) == Enum.reverse(CHash.successors(<<0::160>>, partition_size, chash))
+    assert CHash.predecessors(CHash.key_of(4), partition_size, updated_ring) == Enum.reverse(CHash.successors(CHash.key_of(4), partition_size, updated_ring))
   end
 end

--- a/config/config.exs
+++ b/config/config.exs
@@ -17,8 +17,6 @@ import Config
 #       metadata: [:user_id]
 #
 
-# if Mix.env() == :prod do
-    config :dynamo, :ring_size, 8
-if Mix.env() == :dev do
-    config :dynamo, :vnode_module, Vnode
-end
+config :dynamo,
+  ring_size: 8,
+  replication: 3


### PR DESCRIPTION
I've changed Vnode's `state.data` as `%{index => %{key => value}}` in order to save replicated key/values from other vnodes.


1. A put handle call will put a key/value to it's store.
2. Spawn a separate async process `wait_write_response` to receive responses from other replicating vnodes. 
3. Send async tasks to other vnodes.
4. Wait until `wait_write_response` receives W responses using `Task.await`.

TODOs
1. Read repair
2. Replication for get and delete operations.